### PR TITLE
Add Value() to Tag, returning raw value (name+options)

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -265,13 +265,19 @@ func (t *Tag) HasOption(opt string) bool {
 	return false
 }
 
-// String reassembles the tag into a valid tag field representation
-func (t *Tag) String() string {
+// Value returns the raw value of the tag, i.e. if the tag is
+// `json:"foo,omitempty", the Value is "foo,omitempty"
+func (t *Tag) Value() string {
 	options := strings.Join(t.Options, ",")
 	if options != "" {
-		return fmt.Sprintf(`%s:"%s,%s"`, t.Key, t.Name, options)
+		return fmt.Sprintf(`%s,%s`, t.Name, options)
 	}
-	return fmt.Sprintf(`%s:"%s"`, t.Key, t.Name)
+	return t.Name
+}
+
+// String reassembles the tag into a valid tag field representation
+func (t *Tag) String() string {
+	return fmt.Sprintf(`%s:"%s"`, t.Key, t.Value())
 }
 
 // GoString implements the fmt.GoStringer interface

--- a/tags_test.go
+++ b/tags_test.go
@@ -188,11 +188,18 @@ func TestTags_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := `json:"foo,omitempty"`
-
-	if found.String() != want {
-		t.Errorf("get\n\twant: %#v\n\tgot : %#v", want, found.String())
-	}
+	t.Run("String", func(t *testing.T) {
+		want := `json:"foo,omitempty"`
+		if found.String() != want {
+			t.Errorf("get\n\twant: %#v\n\tgot : %#v", want, found.String())
+		}
+	})
+	t.Run("Value", func(t *testing.T) {
+		want := `foo,omitempty`
+		if found.Value() != want {
+			t.Errorf("get\n\twant: %#v\n\tgot : %#v", want, found.Value())
+		}
+	})
 }
 
 func TestTags_Set(t *testing.T) {


### PR DESCRIPTION
The library is tailored for the convention of a tag's value being a main identifier, optionally followed by comma-separated options, e.g. `` `json:"foo,omitempty"` ``.

But in some cases this convention doesn't make sense, e.g. `` `description:"this is a valid tag, too"` ``. In that case, we would like to retrieve the full raw value (`this is a valid tag, too`) and not have it split as a _Name_ (`this is a valid tag`) and _Options_ (`[]string{" too"}`).

This PR adds a `Value()` method to _Tag_ to allow retrieving the full value.