### PR TITLE
fix the *Tag.String method and add other useful methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+*.zip
+
+.DS_Store

--- a/tags.go
+++ b/tags.go
@@ -277,7 +277,7 @@ func (t *Tag) Value() string {
 
 // String reassembles the tag into a valid tag field representation
 func (t *Tag) String() string {
-	return fmt.Sprintf(`%s:"%s"`, t.Key, t.Value())
+	return fmt.Sprintf(`%s:%q`, t.Key, t.Value())
 }
 
 // GoString implements the fmt.GoStringer interface

--- a/tags.go
+++ b/tags.go
@@ -265,6 +265,35 @@ func (t *Tag) HasOption(opt string) bool {
 	return false
 }
 
+// SetOption sets the given option into tag if it is not existed.
+func (t *Tag) SetOption(opt string) {
+	for _, tagOpt := range t.Options {
+		if tagOpt == opt {
+			return
+		}
+	}
+	t.Options = append(t.Options, opt)
+}
+
+// DeleteOption deletes the given option to tag if it is not existed.
+func (t *Tag) DeleteOption(options ...string) {
+	hasOption := func(option string) bool {
+		for _, opt := range options {
+			if opt == option {
+				return true
+			}
+		}
+		return false
+	}
+	var updated []string
+	for _, opt := range t.Options {
+		if !hasOption(opt) {
+			updated = append(updated, opt)
+		}
+	}
+	t.Options = updated
+}
+
 // Value returns the raw value of the tag, i.e. if the tag is
 // `json:"foo,omitempty", the Value is "foo,omitempty"
 func (t *Tag) Value() string {

--- a/tags.go
+++ b/tags.go
@@ -227,7 +227,7 @@ func (t *Tags) Tags() []*Tag {
 	return t.tags
 }
 
-// Tags returns a slice of tags. The order is the original tag order unless it
+// Keys returns a slice of tag keys. The order is the original tag order unless it
 // was changed.
 func (t *Tags) Keys() []string {
 	var keys []string

--- a/tags.go
+++ b/tags.go
@@ -265,9 +265,9 @@ func (t *Tag) HasOption(opt string) bool {
 	return false
 }
 
-// AddOption sets the given options into tag.
+// AddOptions sets the given options into tag.
 // If the option already exists it doesn't add it again.
-func (t *Tag) AddOption(options ...string) {
+func (t *Tag) AddOptions(options ...string) {
 	for _, opt := range options {
 		if !t.HasOption(opt) {
 			t.Options = append(t.Options, opt)
@@ -275,8 +275,8 @@ func (t *Tag) AddOption(options ...string) {
 	}
 }
 
-// DeleteOption deletes the given options from the tag.
-func (t *Tag) DeleteOption(options ...string) {
+// DeleteOptions deletes the given options from the tag.
+func (t *Tag) DeleteOptions(options ...string) {
 	hasOption := func(option string) bool {
 		for _, opt := range options {
 			if opt == option {

--- a/tags.go
+++ b/tags.go
@@ -265,17 +265,17 @@ func (t *Tag) HasOption(opt string) bool {
 	return false
 }
 
-// SetOption sets the given option into tag if it is not existed.
-func (t *Tag) SetOption(opt string) {
-	for _, tagOpt := range t.Options {
-		if tagOpt == opt {
-			return
+// AddOption sets the given options into tag.
+// If the option already exists it doesn't add it again.
+func (t *Tag) AddOption(options ...string) {
+	for _, opt := range options {
+		if !t.HasOption(opt) {
+			t.Options = append(t.Options, opt)
 		}
 	}
-	t.Options = append(t.Options, opt)
 }
 
-// DeleteOption deletes the given option to tag if it is not existed.
+// DeleteOption deletes the given options from the tag.
 func (t *Tag) DeleteOption(options ...string) {
 	hasOption := func(option string) bool {
 		for _, opt := range options {


### PR DESCRIPTION
- Fix the `*Tag.String` to solve double quotes escaping problem
- Add `.gitignore` file
- Add the `*Tag.AddOptions` method
- Add the `*Tag. DeleteOptions` method