### PR TITLE
ignoring trailing whitespace. fixes #8

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -42,6 +42,8 @@ type Tag struct {
 func Parse(tag string) (*Tags, error) {
 	var tags []*Tag
 
+	hasTag := tag != ""
+
 	// NOTE(arslan) following code is from reflect and vet package with some
 	// modifications to collect all necessary information and extend it with
 	// usable methods
@@ -53,7 +55,7 @@ func Parse(tag string) (*Tags, error) {
 		}
 		tag = tag[i:]
 		if tag == "" {
-			return nil, nil
+			break
 		}
 
 		// Scan to colon. A space, a quote or a control character is a syntax
@@ -111,6 +113,10 @@ func Parse(tag string) (*Tags, error) {
 			Name:    name,
 			Options: options,
 		})
+	}
+
+	if hasTag && len(tags) == 0 {
+		return nil, nil
 	}
 
 	return &Tags{

--- a/tags_test.go
+++ b/tags_test.go
@@ -3,6 +3,7 @@ package structtag
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -162,6 +163,16 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "tag with trailing space",
+			tag:  `json:"foo" `,
+			exp: []*Tag{
+				{
+					Key:  "json",
+					Name: "foo",
+				},
+			},
+		},
 	}
 
 	for _, ts := range test {
@@ -182,8 +193,9 @@ func TestParse(t *testing.T) {
 				t.Errorf("parse\n\twant: %#v\n\tgot : %#v", ts.exp, got)
 			}
 
-			if ts.tag != tags.String() {
-				t.Errorf("parse string\n\twant: %#v\n\tgot : %#v", ts.tag, tags.String())
+			trimmedInput := strings.TrimSpace(ts.tag)
+			if trimmedInput != tags.String() {
+				t.Errorf("parse string\n\twant: %#v\n\tgot : %#v", trimmedInput, tags.String())
 			}
 		})
 	}


### PR DESCRIPTION
One detail about this change: I made no effort to preserve the trailing whitespace and so it doesn't get printed back when the `String` method is used on the parsed tags. The comment on that method indicates it's reassembling the tags to a valid string, so I figured it fit, but lmk if you think otherwise.