### PR TITLE
Export error sentinel values and refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/fatih/structtag
 
-go 1.12
+go 1.21
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tags.go
+++ b/tags.go
@@ -9,13 +9,13 @@ import (
 )
 
 var (
-	errTagSyntax      = errors.New("bad syntax for struct tag pair")
-	errTagKeySyntax   = errors.New("bad syntax for struct tag key")
-	errTagValueSyntax = errors.New("bad syntax for struct tag value")
+	ErrTagSyntax      = errors.New("bad syntax for struct tag pair")
+	ErrTagKeySyntax   = errors.New("bad syntax for struct tag key")
+	ErrTagValueSyntax = errors.New("bad syntax for struct tag value")
 
-	errKeyNotSet      = errors.New("tag key does not exist")
-	errTagNotExist    = errors.New("tag does not exist")
-	errTagKeyMismatch = errors.New("mismatch between key and tag.key")
+	ErrKeyNotSet      = errors.New("tag key does not exist")
+	ErrTagNotExist    = errors.New("tag does not exist")
+	ErrTagKeyMismatch = errors.New("mismatch between key and tag.key")
 )
 
 // Tags represent a set of tags from a single struct field
@@ -69,13 +69,13 @@ func Parse(tag string) (*Tags, error) {
 		}
 
 		if i == 0 {
-			return nil, errTagKeySyntax
+			return nil, ErrTagKeySyntax
 		}
 		if i+1 >= len(tag) || tag[i] != ':' {
-			return nil, errTagSyntax
+			return nil, ErrTagSyntax
 		}
 		if tag[i+1] != '"' {
-			return nil, errTagValueSyntax
+			return nil, ErrTagValueSyntax
 		}
 
 		key := tag[:i]
@@ -90,7 +90,7 @@ func Parse(tag string) (*Tags, error) {
 			i++
 		}
 		if i >= len(tag) {
-			return nil, errTagValueSyntax
+			return nil, ErrTagValueSyntax
 		}
 
 		qvalue := tag[:i+1]
@@ -98,7 +98,7 @@ func Parse(tag string) (*Tags, error) {
 
 		value, err := strconv.Unquote(qvalue)
 		if err != nil {
-			return nil, errTagValueSyntax
+			return nil, ErrTagValueSyntax
 		}
 
 		res := strings.Split(value, ",")
@@ -135,13 +135,13 @@ func (t *Tags) Get(key string) (*Tag, error) {
 		}
 	}
 
-	return nil, errTagNotExist
+	return nil, ErrTagNotExist
 }
 
 // Set sets the given tag. If the tag key already exists it'll override it
 func (t *Tags) Set(tag *Tag) error {
 	if tag.Key == "" {
-		return errKeyNotSet
+		return ErrKeyNotSet
 	}
 
 	added := false
@@ -235,9 +235,9 @@ func (t *Tags) Tags() []*Tag {
 
 // Keys returns a slice of tags' keys.
 func (t *Tags) Keys() []string {
-	var keys []string
-	for _, tag := range t.tags {
-		keys = append(keys, tag.Key)
+	keys := make([]string, len(t.tags))
+	for i := range t.tags {
+		keys[i] = t.tags[i].Key
 	}
 	return keys
 }

--- a/tags.go
+++ b/tags.go
@@ -180,15 +180,6 @@ func (t *Tags) AddOptions(key string, options ...string) {
 
 // DeleteOptions deletes the given options for the given key
 func (t *Tags) DeleteOptions(key string, options ...string) {
-	hasOption := func(option string) bool {
-		for _, opt := range options {
-			if opt == option {
-				return true
-			}
-		}
-		return false
-	}
-
 	for i, tag := range t.tags {
 		if tag.Key != key {
 			continue
@@ -196,7 +187,7 @@ func (t *Tags) DeleteOptions(key string, options ...string) {
 
 		var updated []string
 		for _, opt := range tag.Options {
-			if !hasOption(opt) {
+			if !has(options, opt) {
 				updated = append(updated, opt)
 			}
 		}
@@ -208,18 +199,9 @@ func (t *Tags) DeleteOptions(key string, options ...string) {
 
 // Delete deletes the tag for the given keys
 func (t *Tags) Delete(keys ...string) {
-	hasKey := func(key string) bool {
-		for _, k := range keys {
-			if k == key {
-				return true
-			}
-		}
-		return false
-	}
-
 	var updated []*Tag
 	for _, tag := range t.tags {
-		if !hasKey(tag.Key) {
+		if !has(keys, tag.Key) {
 			updated = append(updated, tag)
 		}
 	}
@@ -261,13 +243,7 @@ func (t *Tags) String() string {
 
 // HasOption returns true if the given option is available in options
 func (t *Tag) HasOption(opt string) bool {
-	for _, tagOpt := range t.Options {
-		if tagOpt == opt {
-			return true
-		}
-	}
-
-	return false
+	return has(t.Options, opt)
 }
 
 // Value returns the raw value of the tag, i.e. if the tag is
@@ -311,4 +287,13 @@ func (t *Tags) Less(i int, j int) bool {
 
 func (t *Tags) Swap(i int, j int) {
 	t.tags[i], t.tags[j] = t.tags[j], t.tags[i]
+}
+
+func has[T comparable](s []T, item T) bool {
+	for i := range s {
+		if s[i] == item {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
chore: Upgrade gomod to Go 1.21.
perf: Preallocate slice in `(*Tags).Keys()`.
test: Add more tests and improve test coverage.
test: Move syntax error testing to `TestParseErr`.
refactor: Use github.com/stretchr/testify to simplify tests.
refactor: Use black-box testing (test package with "_test" suffix).
refactor: Use generic slice search function to reduce code duplication.

A little more than promised, but I hope you're fine with these changes living in 1 PR (saved me time).
Please let me know if you want these changes to be split across multiple PRs.

resolves #24 